### PR TITLE
Standard error base class

### DIFF
--- a/lib/mandrill/errors.rb
+++ b/lib/mandrill/errors.rb
@@ -1,5 +1,5 @@
 module Mandrill
-    class Error < Exception
+    class Error < StandardError
     end
     class ValidationError < Error
     end


### PR DESCRIPTION
StandardError needs to be used to have errors caught with: 

```ruby
begin
  #...
rescue => error
end
```

There is no real reason to have the base class as Exception for this gem. 